### PR TITLE
fixed crd version schema

### DIFF
--- a/hack/helm/templates/crd.yaml
+++ b/hack/helm/templates/crd.yaml
@@ -61,7 +61,10 @@ spec:
             name:
               type: string
           type: object
-  version: v1
+  version:
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This PR fix CRD version schema

ref: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/

erro ref: Error: release uptimerobot failed: CustomResourceDefinition.apiextensions.k8s.io "uptimerobots.monitors.tks.sh" is invalid: [spec.versions: Invalid value: []apiextensions.CustomResourceDefinitionVersion(nil): must have exactly one version marked as storage version, status.storedVersions: Invalid value: []string(nil): must have at least one stored version]